### PR TITLE
fix: TS config and rename docs/ -> react/

### DIFF
--- a/docs/providers/interfaces/WalletProviderState.md
+++ b/docs/providers/interfaces/WalletProviderState.md
@@ -1,6 +1,6 @@
 # Interface: WalletProviderState
 
-This component is a layer of [Wagmi](https://wagmi.sh/docs/getting-started) and [ConnectKit](https://docs.family.co/connectkit)
+This component is a layer of [Wagmi](https://wagmi.sh/react/getting-started) and [ConnectKit](https://docs.family.co/connectkit)
 which allow to handle Metamask, WalletConnect and Coinbase without needing to set any config
 
 ## Table of contents
@@ -47,7 +47,7 @@ All the wagmi client functionalities
 
 **`See`**
 
-[wagmi](https://wagmi.sh/docs/getting-started)
+[wagmi](https://wagmi.sh/react/getting-started)
 
 #### Defined in
 

--- a/docs/providers/modules.md
+++ b/docs/providers/modules.md
@@ -112,12 +112,12 @@ ___
 
 ▸ **WalletProvider**(`config`): `Element`
 
-This component is a layer of [Wagmi](https://wagmi.sh/docs/getting-started) and [ConnectKit](https://docs.family.co/connectkit)
+This component is a layer of [Wagmi](https://wagmi.sh/react/getting-started) and [ConnectKit](https://docs.family.co/connectkit)
 which allow to handle Metamask, WalletConnect and Coinbase without needing to set any config
 
 **`See`**
 
-[wagmi](https://wagmi.sh/docs/getting-started)
+[wagmi](https://wagmi.sh/react/getting-started)
 
 **`Example`**
 

--- a/providers/package.json
+++ b/providers/package.json
@@ -6,7 +6,7 @@
     "watch": "./node_modules/.bin/nodemon",
     "start": "npx tsc --watch",
     "build": "npm run clean && npm run build:tsc",
-    "build:tsc": "tsc --noEmit false",
+    "build:tsc": "tsc --noEmit false --project tsconfig.build.json",
     "clean": "rm -rf dist",
     "test:unit": "jest",
     "eject": "react-scripts eject",

--- a/providers/src/client.tsx
+++ b/providers/src/client.tsx
@@ -74,12 +74,12 @@ export const getClient = (appName = 'Nevermined', autoConnect = true, chainsConf
 }
 
 /**
- * This component is a layer of [Wagmi](https://wagmi.sh/docs/getting-started) and [ConnectKit](https://docs.family.co/connectkit)
+ * This component is a layer of [Wagmi](https://wagmi.sh/react/getting-started) and [ConnectKit](https://docs.family.co/connectkit)
  * which allow to handle Metamask, WalletConnect and Coinbase without needing to set any config 
  */
 export interface WalletProviderState {
 /** All the wagmi client functionalities
- * @see [wagmi](https://wagmi.sh/docs/getting-started)
+ * @see [wagmi](https://wagmi.sh/react/getting-started)
  */
 client: Client
 /** Metamask provider for example web3 or ethers */

--- a/providers/src/providers.tsx
+++ b/providers/src/providers.tsx
@@ -4,11 +4,11 @@ import { ClientComp } from './client'
 import { ConnectKitProviderProps } from './types'
 
 /** 
- * This component is a layer of [Wagmi](https://wagmi.sh/docs/getting-started) and [ConnectKit](https://docs.family.co/connectkit)
+ * This component is a layer of [Wagmi](https://wagmi.sh/react/getting-started) and [ConnectKit](https://docs.family.co/connectkit)
  * which allow to handle Metamask, WalletConnect and Coinbase without needing to set any config 
  * 
  * @param config
- * @param config.client The wagmi client object @see [wagmi](https://wagmi.sh/docs/getting-started)
+ * @param config.client The wagmi client object @see [wagmi](https://wagmi.sh/react/getting-started)
  * @param config.correctNetworkId Id of the default blockchain network in Hexadecimal. Default the fist chain configured
  * @param config.connectKitProps Parameter to pass the options to customize [ConnectKit](https://docs.family.co/connectkit/customization)
  * @returns All the functionalities to handle the wallet in dapp

--- a/providers/tsconfig.build.json
+++ b/providers/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["tests/"]
+}

--- a/providers/tsconfig.json
+++ b/providers/tsconfig.json
@@ -21,6 +21,6 @@
     "sourceMap": false,
     "types": ["jest", "@testing-library/jest-dom"]
   },
-  "include": ["src", "tests"],
+  "include": ["src/", "tests/"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Description

* The previous v0.6.2 accidentally included dist/src and dist/tests folders instead of dist only and because of that the npm package has lost all dist files
* Replaces /docs/ with /react/ for documentation links in *.md files

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] Follows the code style of this project.
- [ ] Tests Cover Changes
- [x] Documentation
